### PR TITLE
App using rm -rf that was unspotted so far ... to be reported as error by the linter

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -101,7 +101,7 @@ then
 	mkdir -p "$final_path/storage/export/"
 	cp -a "$final_path/storage/upload/" "$tmpdir/storage/upload/"
 	cp -a "$final_path/storage/export/" "$tmpdir/storage/export/"
-	rm -Rf "$final_path"
+	ynh_secure_remove "$final_path"
 
 	# Download, check integrity, uncompress and patch the source from app.src
 	ynh_setup_source --dest_dir="$final_path"
@@ -111,7 +111,7 @@ then
 	cp -a "$tmpdir/storage/export/"  "$final_path/storage/export/"
 
 	# Remove temporary directory
-	rm -Rf "$tmpdir"
+	ynh_secure_remove "$tmpdir"
 
 fi
 


### PR DESCRIPTION
c.f. https://github.com/YunoHost/package_linter/commit/4b513b4cd67275dfc597d30ddbfe1801293ad15a#diff-661c3b5fe67e77caea903b5fdb903b5fb6e8277c912d4a4af94e179ade2910baR1019

This app is using some `rm -rf` or similar command that was unspotted so far ... The app is gonna be capped to level 4 by the CI until this is fixed :/ 