### PR TITLE
Readme: Change documentation link in overview section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/install) to learn how to install it.*
 
 ## Overview
-"Firefly III" is a (self-hosted) manager for your personal finances. It can help you keep track of your expenses and income, so you can spend less and save more. Firefly III supports the use of budgets, categories and tags. It can import data from external sources and it has many neat financial reports available. You can [read all about it in the main repository](https://github.com/firefly-iii/firefly-iii) and in the [official documentation](https://firefly-iii.readthedocs.io/en/latest/).
+"Firefly III" is a (self-hosted) manager for your personal finances. It can help you keep track of your expenses and income, so you can spend less and save more. Firefly III supports the use of budgets, categories and tags. It can import data from external sources and it has many neat financial reports available. You can [read all about it in the main repository](https://github.com/firefly-iii/firefly-iii) and in the [official documentation](https://docs.firefly-iii.org/).
 
 **Shipped version:** 5.4.6
 


### PR DESCRIPTION
## Problem
-  The documentation link in the overview was broken
![image](https://user-images.githubusercontent.com/46066895/112349098-bc928980-8cc8-11eb-9971-f5e638146dd4.png)

## Solution
Changed the link to https://docs.firefly-iii.org/
![image](https://user-images.githubusercontent.com/46066895/112349591-2743c500-8cc9-11eb-9a31-a43a1400a1ed.png)

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
