### PR TITLE
Update manifest.json

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,7 +15,7 @@
         "url": "https://datamol.org"
     },
     "requirements": {
-        "yunohost": ">= 4.0.0"
+        "yunohost": ">= 4.1.0"
     },
     "multi_instance": true,
     "services": [


### PR DESCRIPTION
## Problem
    ! Using official helper ynh_legacy_permissions_delete_all implies requiring at least version 4.1, but manifest only requires 4.0.0 
    ! Using official helper ynh_legacy_permissions_exists implies requiring at least version 4.1, but manifest only requires 4.0.0 


## Solution
- *Update manifest.json*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
